### PR TITLE
Alone mode when bot leaves channel

### DIFF
--- a/default-attached/alonemode.js
+++ b/default-attached/alonemode.js
@@ -1,6 +1,6 @@
 registerPlugin({
     name: 'AloneMode',
-    version: '3.0',
+    version: '3.1',
     backends: ['ts3', 'discord'],
     description: 'This script will save CPU and bandwidth by stopping or muting the bot when nobody is listening anyways.',
     author: 'Michael Friese <michael@sinusbot.com>, Max Schmitt <max@schmitt.mx>',
@@ -29,7 +29,8 @@ registerPlugin({
     audio.setMute(false)
 
     event.on('clientMove', () => {
-        let clients = backend.getCurrentChannel().getClientCount()
+        let currentChannel = backend.getCurrentChannel()
+        let clients = currentChannel ? currentChannel.getClientCount() : 0
 
         if (clients > 1 && isMuted) {
             isMuted = false


### PR DESCRIPTION
In the current version, when the bot leaves the channel, it gives an error:

2020-02-14T04:57:35+00:00 error on callback func: Uncaught exception: TypeError: Cannot read property 'getClientCount' of undefined at alonemode:31:49 let clients = backend.getCurrentChannel().getClientCount()

With the changes, you do not get the error anymore and if the bot leaves the channel, you also get the benefit of the alone mode. I am a novice user of the bot, so please analyze if there is more complexity needed for the script.

PS.: The embedded file in the latest beta version does not have the discord backend configured.